### PR TITLE
AP_HAL_ChibiOS: Added ADC channel map for STM325757

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H757xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H757xx.py
@@ -1305,10 +1305,13 @@ ADC2_map = {
 	# format is PIN : ADC2_CHAN
 	"PF13"  :   2,
 	"PB1"	:	5,
+    "PF14"  :   6,
 }
 
 ADC3_map = {
 	# format is PIN : ADC3_CHAN
 	"PC3"   :   1,
 	"PF3"	:   5,
+    "PF5"   :   4,
+    "PF4"   :   9,
 }


### PR DESCRIPTION
Added missing ADC channel maps for the STM32H757